### PR TITLE
Add Chart Deployment for Hedera-The-Graph custom tailored for supporting Hedera Network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,10 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+# chart generated files
+charts/*.tgz
+charts/*.lock
+charts/*.prov
+charts/*.tar.gz

--- a/charts/graph-node/.helmignore
+++ b/charts/graph-node/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/graph-node/Chart.yaml
+++ b/charts/graph-node/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: graph-node
+description: A Helm chart for Graph Protocol Nodes
+type: application
+version: 0.1.0
+keywords:
+  - graphprotocol
+  - hedera
+home: https://github.com/hashgraph/hedera-the-graph
+sources:
+  - https://github.com/graphprotocol/graph-node
+maintainers:
+  - name: Hedera Smart Contracts Team
+    email: engsmartcontracts@hedera.com
+appVersion: v0.1.0

--- a/charts/graph-node/templates/_config.tpl
+++ b/charts/graph-node/templates/_config.tpl
@@ -1,0 +1,43 @@
+# Config.toml based on https://github.com/graphprotocol/graph-node/blob/5613dca92213810b3cca57979f5facc2d670e34a/docs/config.md#configuring-multiple-databases
+{{- define "graph-node.config" -}}
+{{- $pgHost := required "postgres.host wasn't specified" .Values.postgres.host }}
+{{- $pgDB := required "postgres.db wasn't specified" .Values.postgres.db }}
+{{- $pgUser := required "postgres.user wasn't specified" .Values.postgres.user }}
+{{- $pgPass := required "postgres.password wasn't specified" .Values.postgres.password }}
+[store]
+[store.primary]
+  connection = "postgresql://{{ $pgUser }}:{{ $pgPass.value }}@{{ $pgHost }}/{{ $pgDB }}"
+  weight = 1
+  pool_size = 10
+
+{{- if .Values.postgres.replicaHost }}
+[store.primary.replicas.replica]
+  connection = "postgresql://{{ $pgUser }}:{{ $pgPass.value }}@{{ .Values.postgres.replicaHost }}/{{ $pgDB }}"
+  weight = 1
+{{- end }}
+
+[chains]
+  ingestor = "{{ .Values.blockIngestorNodeId }}"
+  {{- range $name, $conf := .Values.config.chains }}
+  [chains.{{ $name }}]
+    shard = "primary"
+    {{- range $conf.providers }}
+    [[chains.{{ $name }}.provider]]
+      label = {{ .label | quote }}
+      url = {{ .url | quote }}
+      features = {{ toJson .features }}
+      transport = {{ default "rpc" .transport | quote }}
+      {{- with .headers }}
+      [headers]
+        {{- range $k, $v := . }}
+        {{ $k }} = {{ $v | quote }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+
+[deployment]
+[[deployment.rule]]
+  shard = "primary"
+  indexers = [ "{{ .Values.blockIngestorNodeId }}" ]
+{{- end }}

--- a/charts/graph-node/templates/_helpers.tpl
+++ b/charts/graph-node/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "graph-node.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "graph-node.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "graph-node.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "graph-node.labels" -}}
+helm.sh/chart: {{ include "graph-node.chart" . }}
+{{ include "graph-node.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "graph-node.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "graph-node.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/graph-node/templates/deployment.yaml
+++ b/charts/graph-node/templates/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+spec:
+  {{/* There shouldn't be more than 1 index (ingest) graph-protocol node in installation */}}
+  {{- if eq .Values.role "index-node" -}}
+  replicas: 1
+  strategy:
+    type: Recreate
+  {{- else -}}
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "graph-node.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret.yaml: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{-   toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "graph-node.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-rta
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - "until nc -z -w2 {{ .Values.postgres.host }} 5432; do echo 'waiting for postgres'; sleep 2; done;"
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{ if eq .Values.role "index-node" }}
+            {{- /* Index (ingest) node_id should equal BLOCK_INGESTOR env value to work in this mode */}}
+            - name: BLOCK_INGESTOR
+              value: {{ .Values.blockIngestorNodeId | quote }}
+            - name: node_id
+              value: {{ .Values.blockIngestorNodeId | quote }}
+            {{- else -}}
+            - name: node_id
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- end }}
+            - name: node_role
+              value: {{ .Values.role | quote }}
+            - name: GRAPH_KILL_IF_UNRESPONSIVE
+              value: "false"
+            - name: ipfs
+              value: {{ required "config.ipfs wasn't specified" .Values.config.ipfs | quote }}
+            - name: GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH
+              value: "true"
+            - name: GRAPH_NODE_CONFIG
+              value: "/etc/graph-node/config.toml"
+            - name: PG_PASS
+              valueFrom:
+                secretKeyRef:
+                {{- if hasKey .Values.postgres.password "fromSecret" }}
+                  name: {{ .Values.postgres.password.fromSecret.name }}
+                  key: {{ .Values.postgres.password.fromSecret.key }}
+                {{- else }}
+                  name: {{ include "graph-node.fullname" . }}
+                  key: pgPass
+                {{- end }}
+            - name: GRAPH_LOG
+            value: debug
+          ports:
+            - name: metrics
+              containerPort: 8040
+              protocol: TCP
+            - name: json-rpc
+              containerPort: 8020
+              protocol: TCP
+            - name: graphql
+              containerPort: 8000
+              protocol: TCP
+            - name: graphql-ws
+              containerPort: 8001
+              protocol: TCP
+            {{- if eq .Values.role "index-node" }}
+            - name: index
+              containerPort: 8030
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: config
+            mountPath: "/etc/graph-node"
+            readOnly: true
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ include "graph-node.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/graph-node/templates/ingress.yaml
+++ b/charts/graph-node/templates/ingress.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: nginx
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "graph-node.fullname" $ }}
+                port:
+                  name: graphql
+    {{- end }}
+{{- end }}
+---
+{{- if .Values.ingressWebsocket.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "graph-node.fullname" . }}-ws
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+  {{- with .Values.ingressWebsocket.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: nginx
+  {{- if .Values.ingressWebsocket.tls }}
+  tls:
+    {{- range .Values.ingressWebsocket.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingressWebsocket.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "graph-node.fullname" $ }}
+                port:
+                  name: graphql-ws
+    {{- end }}
+{{- end }}

--- a/charts/graph-node/templates/secret.yaml
+++ b/charts/graph-node/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+data:
+  config.toml: {{ include "graph-node.config" . | b64enc }}
+  {{- if not (hasKey .Values.postgres.password "fromSecret") }}
+  pgPass: {{ .Values.postgres.password.value | b64enc | quote }}
+  {{- end }}
+  

--- a/charts/graph-node/templates/service.yaml
+++ b/charts/graph-node/templates/service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+  {{-   toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    - port: {{ .Values.service.jsonRpcPort }}
+      targetPort: json-rpc
+      protocol: TCP
+      name: json-rpc
+    - port: {{ .Values.service.graphqlPort }}
+      targetPort: graphql
+      protocol: TCP
+      name: graphql
+    - port: {{ .Values.service.graphqlWsPort }}
+      targetPort: graphql-ws
+      protocol: TCP
+      name: graphql-ws
+    {{- if eq .Values.role "index-node" }}
+    - port: {{ .Values.service.indexPort }}
+      targetPort: index
+      protocol: TCP
+      name: index
+    {{- end }}
+  selector:
+    {{- include "graph-node.selectorLabels" . | nindent 4 }}

--- a/charts/graph-node/templates/servicemonitor.yaml
+++ b/charts/graph-node/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.monitoring.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "graph-node.fullname" . }}
+  labels:
+    {{- include "graph-node.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "graph-node.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: metrics
+{{- end -}}

--- a/charts/graph-node/values.yaml
+++ b/charts/graph-node/values.yaml
@@ -1,0 +1,110 @@
+# Default values for graph-node.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: graphprotocol/graph-node
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.29.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  annotations: {}
+  type: ClusterIP
+  metricsPort: 8040
+  jsonRpcPort: 8020
+  graphqlPort: 8000
+  graphqlWsPort: 8001
+  indexPort: 8030
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config:
+  ipfs: ""
+  chains: {}
+    # mainnet:
+    #   providers:
+    #   - label: name
+    #     transport: rpc
+    #     url: url
+    #     features: [ archive ]
+    #     headers: {"Authorization": "Bearer foo"}
+
+postgres:
+  db: ""
+  host: ""
+  replicaHost: ""
+  user: ""
+  password:
+    value: ""
+    # fromSecret:
+    #   name:
+    #   key:
+
+# Shouldn't have - sign, cause it would be replaced with _
+blockIngestorNodeId: index_node
+
+# Possible values: query-node, index-node
+role: "query-node"
+
+monitoring:
+  enabled: false
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    # - host: chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingressWebsocket:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    # - host: chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/hedera-thegraph/.helmignore
+++ b/charts/hedera-thegraph/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hedera-thegraph/Chart.yaml
+++ b/charts/hedera-thegraph/Chart.yaml
@@ -1,0 +1,43 @@
+apiVersion: v2
+name: hedera-the-graph
+appVersion: "v0.28.2"
+description: Umbrella Helm chart deployment of the hedera-the-graph
+home: https://github.com/hashgraph/hedera-the-graph
+icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
+keywords:
+  - blockchain
+  - dlt
+  - hedera
+  - hashgraph
+  - smart
+  - contracts
+  - evm
+  - relay
+  - subgraph
+  - graphql
+  - thegraph
+  - graph-node
+maintainers:
+  - name: Hedera Smart Contracts Team
+    email: engsmartcontracts@hedera.com
+sources:
+  - https://github.com/hashgraph/hedera-the-graph
+type: application
+version: 0.1.0
+dependencies:
+  - alias: postgresql
+    condition: postgresql.enabled
+    name: postgresql-ha
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.8.1
+  - alias: ipfs
+    name: ipfs
+    condition: ipfs.enabled
+    repository: https://charts.truecharts.org/
+    version: 7.0.3
+  - alias: index-node
+    name: graph-node
+    condition: index-node.enabled
+    repository: file://../graph-node
+    version: 0.1.0
+    

--- a/charts/hedera-thegraph/templates/_helpers.tpl
+++ b/charts/hedera-thegraph/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hedera-the-graph.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hedera-the-graph.name" -}}
+{{- if .Values.global.useReleaseForNameLabel -}}
+{{- .Release.Name -}}
+{{- else -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespace
+*/}}
+{{- define "hedera-the-graph.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespaceOverride -}}
+{{- end -}}
+
+{{/*
+Constructs the database host that should be used by all components.
+*/}}
+{{- define "hedera-the-graph.db" -}}
+{{- if .Values.db.host -}}
+{{- tpl .Values.db.host . -}}
+{{- else if and .Values.postgresql.enabled (gt (.Values.postgresql.pgpool.replicaCount | int) 0) -}}
+{{- include "postgresql-ha.pgpool" .Subcharts.postgresql -}}
+{{- else if .Values.postgresql.enabled -}}
+{{- include "postgresql-ha.postgresql" .Subcharts.postgresql -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Constructs the ipfs host that should be used by all components.
+*/}}
+{{- define "hedera-the-graph.ipfs" -}}
+{{- if .Values.ipfs.host -}}
+{{- tpl .Values.ipfs.host . -}}
+{{- else if .Values.ipfs.enabled -}}
+{{ .Release.Name }}-ipfs:{{- .Values.ipfs.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "hedera-the-graph.labels" -}}
+{{ include "hedera-the-graph.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: hedera-the-graph
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "hedera-the-graph.chart" . }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hedera-the-graph.selectorLabels" -}}
+app.kubernetes.io/component: hedera-the-graph
+app.kubernetes.io/name: {{ include "hedera-the-graph.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/hedera-thegraph/templates/secrets.yaml
+++ b/charts/hedera-thegraph/templates/secrets.yaml
@@ -1,0 +1,15 @@
+{{- $name := "hedera-the-graph-passwords" -}}  # postgresl-ha doesn't support templated names
+{{- $dbHost := include "hedera-the-graph.db" . -}}
+{{- $dbName := .Values.db.name -}}
+{{- $ipfsHost := include "hedera-the-graph.ipfs" . -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{ include "hedera-the-graph.labels" . | nindent 4 }}
+  name: {{ $name }}
+  namespace: {{ include "hedera-the-graph.namespace" . }}
+stringData:
+  DB_HOST: "{{ $dbHost }}"
+  DB_NAME: "{{ $dbName }}"
+  IPFS_HOST: "{{ $ipfsHost }}"

--- a/charts/hedera-thegraph/values.yaml
+++ b/charts/hedera-thegraph/values.yaml
@@ -1,0 +1,51 @@
+nameOverride: hedera-the-graph
+
+global:
+  hostname: ""
+  image: {}
+  namespaceOverride: ""
+  podAnnotations: {}
+  useReleaseForNameLabel: false  # Set the name label to the release name for Marketplace
+
+labels: {}
+
+db:
+  host: ""  # Auto-generated from the database sub-charts
+  name: postgres
+  schema: public
+  owner:
+    password: ""  # Randomly generated if left blank
+    username: postgres
+
+ipfs:
+  enabled: true
+  host: "" # Auto-generated from the ipfs sub-charts
+  port: 10125
+
+
+postgresql:
+  enabled: true
+  pgpool:
+    adminPassword: "unsecured-password"
+  postgresql:
+    password: "unsecured-password"
+    repmgrPassword: "unsecured-password"
+
+index-node:
+  role: "index-node"
+  enabled: true
+  config:
+    ipfs: "htg2-ipfs:10125"
+    chains: 
+      mainnet:
+        providers:
+        - label: hedera-mainnet
+          transport: rpc
+          url: https://mainnet.hashio.io/api
+          features: []
+  postgres:
+    host: htg2-postgresql-pgpool
+    user: "postgres"
+    db: "postgres"
+    password: 
+      value: "unsecured-password"


### PR DESCRIPTION
**Description**:
- Included 2 Charts
- Graph-Node
- Hedera-The-Graph (Umbrella Chart)

Using the following dependencies (sub-charts):
- IPFS from truecharts
- Postgres from bitnami

**Related issue(s)**:

Fixes #4 

**Notes for reviewer**:
Note that this `Draft` is still a WIP and have pending the following changes:

- Move to shared secret file, the hostnames for ipfs and postgres database.
- Move to shared secret file the passwords for the postgres database.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
