### PR TITLE
SQL Clean-up Script for Network Resets

### DIFF
--- a/scripts/db/cleanup.sql
+++ b/scripts/db/cleanup.sql
@@ -1,0 +1,40 @@
+DO $$
+DECLARE
+    drop_schemas_cmd text;
+    drop_tables_cmd text;
+    drop_views_cmd text;
+BEGIN
+    -- Prepare command to drop all non-system schemas except 'public'
+    SELECT INTO drop_schemas_cmd
+        string_agg('DROP SCHEMA ' || quote_ident(schema_name) || ' CASCADE', '; ')
+    FROM information_schema.schemata
+    WHERE schema_name NOT IN ('public', 'information_schema', 'pg_catalog', 'pg_toast', 'pg_temp_4', 'pg_toast_temp_4');
+
+    -- Execute if command is not null
+    IF drop_schemas_cmd IS NOT NULL THEN
+        EXECUTE drop_schemas_cmd;
+    END IF;
+
+    -- Prepare command to drop all user-created tables in the 'public' schema
+    SELECT INTO drop_tables_cmd
+        string_agg('DROP TABLE IF EXISTS public.' || quote_ident(table_name) || ' CASCADE', '; ')
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+          AND table_name NOT LIKE 'pg_%';
+
+    -- Execute if command is not null
+    IF drop_tables_cmd IS NOT NULL THEN
+        EXECUTE drop_tables_cmd;
+    END IF;
+
+    -- Prepare command to drop all user-created views in the 'public' schema
+    SELECT INTO drop_views_cmd
+        string_agg('DROP VIEW IF EXISTS public.' || quote_ident(table_name) || ' CASCADE', '; ')
+    FROM information_schema.views
+    WHERE table_schema = 'public' AND table_name NOT LIKE 'pg_%';
+
+    -- Execute if command is not null
+    IF drop_views_cmd IS NOT NULL THEN
+        EXECUTE drop_views_cmd;
+    END IF;
+END $$;


### PR DESCRIPTION
**Description**:

Added a SQL Script to remove all data from Postgres instance, this removes all configuration and data.

Due to network resets for previewnet and testnet, every time the network is reseted we need to cleanup the database for thegraph instance of such networks.

On restart the graph-node will re-generate all the configuration tables. And all the subgraphs and its data is no longer valid after a network reset.


**Related issue(s)**:

Fixes #26 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
