### PR TITLE
fix: CI Breaked, TrueCharts helm repository changed, needed for IPFS service install

### DIFF
--- a/charts/hedera-the-graph/Chart.yaml
+++ b/charts/hedera-the-graph/Chart.yaml
@@ -34,8 +34,8 @@ dependencies:
   - alias: ipfs
     name: ipfs
     condition: ipfs.enabled
-    repository: https://charts.truecharts.org/
-    version: 7.0.3
+    repository: oci://tccr.io/truecharts
+    version: 9.1.6
 
   - alias: index-node
     name: hedera-the-graph-node


### PR DESCRIPTION
**Description**:
The CI started to fail a couple weeks/days ago due to a repo not found, thank to the CI tests in place we found out while pushing another PR. upon further research, I found that the helm https repo was down and that they replaced it for an OCI based one.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
