### PR TITLE
Build and Publish Docker Images to Registry

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,0 +1,44 @@
+name: Release Integration Environment
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  OWNER: hashgraph
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+
+      - name: Build and push images
+        uses: docker/build-push-action@v2
+        with:
+          context: ./auth-layer-proxy
+          file: ./auth-layer-proxy/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-main

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,0 +1,47 @@
+name: Release Production Environment
+
+on:
+  push:
+    tags: [ v* ]
+
+env:
+  OWNER: hashgraph
+  PACKAGE_NAME: hedera-the-graph
+  REGISTRY: ghcr.io
+
+jobs:
+  docker-image-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Get tag
+        run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+
+      - name: Build and push auth-layer-proxy image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./auth-layer-proxy
+          file: ./auth-layer-proxy/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-${{env.TAG}}


### PR DESCRIPTION
**Description**:
Add workflows for build and publish the docker images of `hedera-the-graph-auth-layer-proxy`

both, integration and production workflows

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
