### PR TITLE
Fix issue with using an auth-server behind HTTPS and SSL certificate.

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -39,6 +39,6 @@ jobs:
           file: ./auth-layer-proxy/Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-main

--- a/auth-layer-proxy/Dockerfile
+++ b/auth-layer-proxy/Dockerfile
@@ -9,9 +9,10 @@ COPY /scripts/start-envoy.sh /etc/envoy/start-envoy.sh
 RUN chmod +x /etc/envoy/start-envoy.sh && \
     chown -R envoy:envoy /etc/envoy && \
     apt-get update && \
-    apt-get install -y gettext-base=0.19.* lua5.1=5.1.* luarocks=2.4.* git=1:2.* && \
+    apt-get install -y gettext-base=0.19.* lua5.1=5.1.* luarocks=2.4.* git=1:2.* libssl-dev=1.1.* && \
     luarocks install lua-cjson && \
     luarocks install luasocket && \
+    luarocks install luasec OPENSSL_LIBDIR=/usr/lib/aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
 # Use the non-root 'envoy' user to run the container

--- a/auth-layer-proxy/Dockerfile
+++ b/auth-layer-proxy/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /etc/envoy/start-envoy.sh && \
     apt-get install -y gettext-base=0.19.* lua5.1=5.1.* luarocks=2.4.* git=1:2.* libssl-dev=1.1.* && \
     luarocks install lua-cjson && \
     luarocks install luasocket && \
-    luarocks install luasec OPENSSL_LIBDIR=/usr/lib/aarch64-linux-gnu && \
+    luarocks install luasec && \
     rm -rf /var/lib/apt/lists/*
 
 # Use the non-root 'envoy' user to run the container

--- a/auth-layer-proxy/README.md
+++ b/auth-layer-proxy/README.md
@@ -96,6 +96,12 @@ For instructions on how to set-up the Auth Provider using KeyCloak, refer to the
 docker build -t envoy-auth-proxy .
 ```
 
+#### On Mac M1
+
+```bash
+docker build --platform linux/amd64 -t envoy-auth-proxy .
+```
+
 ### Configure the environment
 
 Add Postgres or Redis credentials to the .env file


### PR DESCRIPTION
**Description**:
When we were testing the deployment on the cloud and using the HTTPS `auth-server` we found this issue:
```

[2024-04-09 17:00:49.398][20][error][lua] [source/extensions/filters/http/lua/lua_filter.cc:926] script log: /usr/local/share/lua/5.1/socket/http.lua:39: module 'ssl.https' not found:

```

This was due to the lack of the lua component necessary to validate the SSL Certificate of the server, due to a missing component.

This PR fixes this by adding the necessary components

**Related issue(s)**:

Fixes #55

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
