### PR TITLE
ci: 74 latest update breaks integration environment push in gha

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -11,6 +11,7 @@ defaults:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   OWNER: hashgraph

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -10,6 +10,7 @@ defaults:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   OWNER: hashgraph


### PR DESCRIPTION
**Description**:

This PR modifies the release workflows in order to support publishing at the end.
* Add packages:write permission to reelease-production and release-integration files


**Related issue(s)**:

Fixes #74

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
