### PR TITLE
Helm publish job and Readme

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -59,3 +59,33 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-${{ env.TAG }}
+
+  helm-chart-release:
+    runs-on: [self-hosted, Linux, medium, ephemeral]
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+
+      - name: Publish helm chart
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          charts_dir: charts
+          target_dir: charts
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ All features should see a feature branch created and a PR taking the changes fro
 
 Periodically, release branches e.g. `release/0.1` will be created.
 
+## Helm Charts
+This repo contains a `charts` directory that contains the various charts that are used to deploy the Hedera-The-Graph node to a Kubernetes cluster. To get started first install the helm repo:
+```
+helm repo add hedera-the-graph https://hashgraph.github.io/hedera-the-graph/charts
+helm repo update
+```
+
+Then you can install the chart with the following command:
+```
+helm install [RELEASE_NAME] hedera-the-graph/[CHART_NAME] -f [VALUES_FILE]
+```
+
+**CHART_NAME** is the name of the chart you want to install. The available charts are:
+- **hedera-the-graph:** An umbrella chart that installs all the necessary components to run the Hedera-The-Graph node. More information [here](https://github.com/hashgraph/hedera-the-graph/tree/main/charts/hedera-the-graph)
+- **hedera-the-graph-node:** An optimized graph node for the Hedera network.
+-  **hedera-the-graph-auth-layer:** An umbrella chart that installs both the `auth-layer-proxy` and the `auth-layer-server`. More information [here](https://github.com/hashgraph/hedera-the-graph/tree/main/charts/hedera-the-graph-auth-layer)
+- **auth-layer-proxy:** An EnvoyProxy that acts as a reverse proxy that forwards requests to the configured index node, and also verifies the JWT token using the configured authentication server. More informoation: [here](https://github.com/hashgraph/hedera-the-graph/tree/main/charts/auth-layer-proxy)
+- **auth-layer-server:** A KeyCloak server that is pre-configured to work with the `auth-layer-proxy` to generate and verify JWT tokens used for protecting the index node. More information [here](https://github.com/hashgraph/hedera-the-graph/tree/main/charts/auth-layer-server)
+
+**VALUES_FILE** is the path to the values file that you want to use to configure the chart. The values file should be a yaml file that contains the configuration for the chart. The available configuration options for each chart can be found in the chart's README file of the respective chart, linked above.
+
+
 ## Support
 
 If you have a question on how to use the product, please see our

--- a/auth-layer-proxy/Dockerfile
+++ b/auth-layer-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.30-latest
+FROM envoyproxy/envoy:v1.28-latest
 
 # Copy all necessary files
 COPY /filters/ /etc/envoy/filters/


### PR DESCRIPTION
**Description**:
Adding helm-chart-release GHA job on release-production workflow. 
To publish charts and adding documentation on how to use it.

Added Readme notes on how to install and deploy the charts

**Related issue(s)**:

Fixes #91 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
