### PR TITLE
Release `0.1.0` prep work

### DIFF
--- a/charts/auth-layer-proxy/Chart.yaml
+++ b/charts/auth-layer-proxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: auth-layer-proxy
 description: A Helm chart for deploying the auth-layer-proxy onto a Kubernetes cluster
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.0-SNAPSHOT
+appVersion: "main"

--- a/charts/auth-layer-proxy/values.yaml
+++ b/charts/auth-layer-proxy/values.yaml
@@ -25,7 +25,7 @@ global:
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/hashgraph/hedera-the-graph
-  tag: "0.1.0"
+  tag: "main"
   tagPrefix: "auth-layer-proxy-"
 
 imagePullSecrets: []

--- a/charts/auth-layer-proxy/values.yaml
+++ b/charts/auth-layer-proxy/values.yaml
@@ -25,7 +25,7 @@ global:
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/hashgraph/hedera-the-graph
-  tag: "main"
+  tag: "0.1.0"
   tagPrefix: "auth-layer-proxy-"
 
 imagePullSecrets: []

--- a/charts/auth-layer-server/Chart.yaml
+++ b/charts/auth-layer-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth-layer-server
 description: A Helm chart for Authentication layer server for HederaTheGraph using Keycloak Bitnami chart as a base
 type: application
-version: 0.1.0
+version: 0.1.0-SNAPSHOT
 dependencies:
   - alias: keycloak
     name: keycloak

--- a/charts/auth-layer-server/Chart.yaml
+++ b/charts/auth-layer-server/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 name: auth-layer-server
-appVersion: "19.1.0"
 description: A Helm chart for Authentication layer server for HederaTheGraph using Keycloak Bitnami chart as a base
 type: application
 version: 0.1.0

--- a/charts/hedera-the-graph-auth-layer/Chart.yaml
+++ b/charts/hedera-the-graph-auth-layer/Chart.yaml
@@ -22,16 +22,16 @@ maintainers:
 sources:
   - https://github.com/hashgraph/hedera-the-graph
 type: application
-version: 0.1.0
+version: 0.1.0-SNAPSHOT
 dependencies:
   - alias: auth-server
     name: auth-layer-server
     condition: auth-server.enabled
     repository: file://../auth-layer-server
-    version: 0.1.0
+    version: 0.1.0-SNAPSHOT
 
   - alias: auth-proxy
     name: auth-layer-proxy
     condition: auth-proxy.enabled
     repository: file://../auth-layer-proxy
-    version: 0.1.0
+    version: 0.1.0-SNAPSHOT

--- a/charts/hedera-the-graph-auth-layer/Chart.yaml
+++ b/charts/hedera-the-graph-auth-layer/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 name: hedera-the-graph
-appVersion: "0.1.0"
 description: Umbrella Helm chart deployment of the hedera-the-graph auth layer, includes auth-layer-server and auth-layer-proxy
 home: https://github.com/hashgraph/hedera-the-graph
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -23,7 +22,7 @@ maintainers:
 sources:
   - https://github.com/hashgraph/hedera-the-graph
 type: application
-version: 0.0.1
+version: 0.1.0
 dependencies:
   - alias: auth-server
     name: auth-layer-server

--- a/charts/hedera-the-graph-node/Chart.yaml
+++ b/charts/hedera-the-graph-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hedera-the-graph-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.1.0
+version: 0.1.0-SNAPSHOT
 keywords:
   - graphprotocol
   - hedera

--- a/charts/hedera-the-graph-node/Chart.yaml
+++ b/charts/hedera-the-graph-node/Chart.yaml
@@ -14,4 +14,4 @@ sources:
 maintainers:
   - name: Hedera Smart Contracts Team
     email: engsmartcontracts@hedera.com
-appVersion: v0.1.0
+appVersion: "v0.29.0"

--- a/charts/hedera-the-graph/Chart.yaml
+++ b/charts/hedera-the-graph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hedera-the-graph
-appVersion: "0.1.0"
+version: 0.1.0
 description: Umbrella Helm chart deployment of the hedera-the-graph
 home: https://github.com/hashgraph/hedera-the-graph
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -23,7 +23,6 @@ maintainers:
 sources:
   - https://github.com/hashgraph/hedera-the-graph
 type: application
-version: 0.28.2
 dependencies:
   - alias: postgresql
     condition: postgresql.enabled

--- a/charts/hedera-the-graph/Chart.yaml
+++ b/charts/hedera-the-graph/Chart.yaml
@@ -46,4 +46,4 @@ dependencies:
     name: hedera-the-graph-node
     condition: query-node.enabled
     repository: file://../hedera-the-graph-node
-    version: 00.1.0-SNAPSHOT
+    version: 0.1.0-SNAPSHOT

--- a/charts/hedera-the-graph/Chart.yaml
+++ b/charts/hedera-the-graph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hedera-the-graph
-version: 0.1.0
+version: 0.1.0-SNAPSHOT
 description: Umbrella Helm chart deployment of the hedera-the-graph
 home: https://github.com/hashgraph/hedera-the-graph
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -40,10 +40,10 @@ dependencies:
     name: hedera-the-graph-node
     condition: index-node.enabled
     repository: file://../hedera-the-graph-node
-    version: 0.1.0
+    version: 0.1.0-SNAPSHOT
 
   - alias: query-node
     name: hedera-the-graph-node
     condition: query-node.enabled
     repository: file://../hedera-the-graph-node
-    version: 0.1.0
+    version: 00.1.0-SNAPSHOT


### PR DESCRIPTION
**Description**:
- Set every chart version on main to `0.1.0-SNAPSHOT` in preparation for next release.

- Removed unneeded and unused appVersion field from auth-layer-server chart.

- hedera-the-graph umbrella chart, removed appVersion since is not being used, and updated version to correct `0.1.0-SNAPSHOT` to correspond with the current release in progress.

- hedera-the-graph-auth-layer umbrella chart, fixed the version on the chart and removed the appVersion since is not being used and completely unneeded.

- hedera-the-graph-node, changed appVersion to correct value, this is being used in case is not provided on the values file for selecting the version of the graph-node image from thegraph protocol repo.

**Related issue(s)**:
#91 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
