### PR TITLE
Remove release for `arm` architecture due to dependencies issues

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -56,7 +56,7 @@ jobs:
           file: ./auth-layer-proxy/Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-${{ env.TAG }}
 


### PR DESCRIPTION
**Description**:
Remove release for `arm` architecture due to dependencies issues for such architecture.

It can still be run on M1 with Docker compatibility mode.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
