### PR TITLE
Update helm charts to latest version of The Graph

### DIFF
--- a/charts/hedera-the-graph-node/Chart.yaml
+++ b/charts/hedera-the-graph-node/Chart.yaml
@@ -14,4 +14,4 @@ sources:
 maintainers:
   - name: Hedera Smart Contracts Team
     email: engsmartcontracts@hedera.com
-appVersion: "v0.29.0"
+appVersion: "v0.35.1"

--- a/charts/hedera-the-graph-node/values.yaml
+++ b/charts/hedera-the-graph-node/values.yaml
@@ -38,7 +38,7 @@ image:
   pullPolicy: IfNotPresent
   repository: graphprotocol/graph-node
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.29.0
+  tag: v0.35.1
 
 imagePullSecrets: []
 

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -102,7 +102,6 @@ postgresql:
   # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#postgresql-with-repmgr-parameters
   postgresql:
     extraEnvVars:
-      # POSTGRES_INITDB_ARGS
       # This is needed because starting from `v0.30.0` https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0
       # of the graph-node, the encoding and locale options are required on new PostgreSQL databases.
       # 

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -102,6 +102,12 @@ postgresql:
   # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#postgresql-with-repmgr-parameters
   postgresql:
     extraEnvVars:
+      # POSTGRES_INITDB_ARGS
+      # This is needed because starting from `v0.30.0` https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0
+      # of the graph-node, the encoding and locale options are required on new PostgreSQL databases.
+      # 
+      # For more details, see `POSTGRES_INITDB_ARGS` in https://hub.docker.com/_/postgres, `Environment Variables` section and
+      # https://github.com/bitnami/charts/tree/main/bitnami/postgresql#differences-between-bitnami-postgresql-image-and-docker-official-image
       - name: POSTGRES_INITDB_ARGS
         value: "-E UTF8 --locale=C"
     existingSecret: hedera-the-graph-passwords

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -28,7 +28,7 @@ index-node:
         name: hedera-the-graph-configmap
   enabled: true
   image:
-    tag: v0.28.2
+    tag: v0.35.1
   postgres:
     db:
       # value: "<postgres-db-name>"
@@ -129,7 +129,7 @@ query-node:
         name: hedera-the-graph-configmap
   enabled: true
   image:
-    tag: v0.28.2
+    tag: v0.35.1
   postgres:
     db:
       # value: "<postgres-db-name>"

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -104,7 +104,7 @@ postgresql:
     extraEnvVars:
       # This is needed because starting from `v0.30.0` https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0
       # of the graph-node, the encoding and locale options are required on new PostgreSQL databases.
-      # 
+      #
       # For more details, see `POSTGRES_INITDB_ARGS` in https://hub.docker.com/_/postgres, `Environment Variables` section and
       # https://github.com/bitnami/charts/tree/main/bitnami/postgresql#differences-between-bitnami-postgresql-image-and-docker-official-image
       - name: POSTGRES_INITDB_ARGS

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -101,6 +101,9 @@ postgresql:
         memory: 256Mi
   # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#postgresql-with-repmgr-parameters
   postgresql:
+    extraEnvVars:
+      - name: POSTGRES_INITDB_ARGS
+        value: "-E UTF8 --locale=C"
     existingSecret: hedera-the-graph-passwords
     extraEnvVarsSecret: hedera-the-graph-passwords
     replicaCount: 1


### PR DESCRIPTION
**Description**:

This PR updates the Helm chart for `hedera-the-graph-node` to its latest version `v0.35.1`.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #87.
Fixes #231.

> [!NOTE]
> The Graph DB should be migrated automatically by the upgrade process. However, given we are running a version too distant apart, manual intervention might be needed.

> [!IMPORTANT]
> The Graph DB should be backed up before starting with the upgrade process to ensure data can be recovered in case a problem arises in the migration process.

> [!IMPORTANT]
> Perform an upgrade in a local environment to ensure it works as expected.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
