### PR TITLE
chore: fix codeowners for workflows dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,23 +27,23 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
-.remarkrc                                       @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+/config/                                        @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+.remarkrc                                       @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+/README.md                                      @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
 **/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+**/codecov.yml                                  @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+**/.gitignore                                   @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,8 +27,8 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts 
+/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
 
 # Codacy Tool Configurations
 /config/                                        @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts


### PR DESCRIPTION
**Description**:
Resolve the CODEOWNER file so the line reads:

`/.github/workflows/    @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers`

If there are additional owners on the `/.github` folder, that should be declared in a separate line.

**Related issue(s)**:

Fixes #173 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
