### PR TITLE
fix: ensure pods start properly

### DIFF
--- a/.github/workflows/charts-lint.yml
+++ b/.github/workflows/charts-lint.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: 'v3.17.3'
 
       - name: Install ct
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0

--- a/.github/workflows/hedera-the-graph-chart-install.yml
+++ b/.github/workflows/hedera-the-graph-chart-install.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: 'v3.17.3'
 
       - name: Install kubectl
         uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0

--- a/charts/hedera-the-graph/README.md
+++ b/charts/hedera-the-graph/README.md
@@ -11,9 +11,12 @@ This is a Helm chart for deploying a Hedera The Graph node, which is a node that
 
 ## Configuration
 
-### Values for installing all components.
+> [!TIP]
+> You can also override any value in the chart using the `--set*` flags when executing a [`helm install`](https://helm.sh/docs/helm/helm_install).
 
-No need to change any values if want to install all components and auto-generate a password for the postgres database.
+### Values for installing all components
+
+No need to change any values if want to install all components and auto-generate a password for the Postgres database.
 
 If wish to provide a custom password for the postgres database, set the following values:
 
@@ -24,9 +27,15 @@ global:
 
 ```
 
-### Values when using external ipfs server.
+Or alternatively,
 
-example to use `ipfs.infura.io` as external ipfs server.
+```sh
+helm install <RELEASE-NAME> . --set-string global.postgresql.password=1234
+```
+
+### Values when using external ipfs server
+
+Example to use `ipfs.infura.io` as external ipfs server.
 
 ```yaml
 ipfs:
@@ -35,9 +44,20 @@ ipfs:
   port: 5001
 ```
 
-### Values when using external postgres server.
+### Values when using internal IPFS server on a ARM64 host
 
-example to use `postgresql://postgres:password@remotehost:5432/graph-node` as external postgres server.
+By default, the IPFS node runs only on AMD64 hosts.
+If you are running on an ARM64 architecture, such as Apple Silicon Macs,
+you will need to change the arch selector.
+You can do so by running the following
+
+```sh
+helm install <RELEASE-NAME> . -f values-overrides/arm-arch.yaml 
+```
+
+### Values when using external postgres server
+
+Example to use `postgresql://postgres:password@remotehost:5432/graph-node` as external postgres server.
 
 ```yaml
 global:
@@ -48,7 +68,6 @@ global:
         password: "password"
         database: "graph-node"
 ```
-
 
 ### Index and Query Nodes
 

--- a/charts/hedera-the-graph/README.md
+++ b/charts/hedera-the-graph/README.md
@@ -92,8 +92,10 @@ query-node:
 
 The default number of replicas for the Query Node is 1.
 
-#### Values if you don't want dedicated query node.
-Is possible to do queries using the index node, so for small testing environments is possible to disable the query node and use the index node for queries.
+#### Values if you do not want dedicated query node
+
+Is possible to do queries using the index node,
+so for small testing environments is possible to disable the query node and use the index node for queries.
 
   ```yaml
   query-node:
@@ -102,13 +104,15 @@ Is possible to do queries using the index node, so for small testing environment
 
 ## RPC Provider Configuration Overview
 
-This section details the override values specified for different network environments: previewnet, testnet, and mainnet. The configuration files are organized as follows:
-```
+This section details the override values specified for different network environments: previewnet, testnet, and mainnet. The configuration files are organized as follows
+
+```plain
     /values-overrides
         /values-mainnet.yaml
         /values-previewnet.yaml
         /values-testnet.yaml
 ```
+
 ### Support for Archive Feature
 
 The Hedera JSON RPC Relay now includes support for the archive feature, as outlined in [HIP-584](https://hips.hedera.com/hip/hip-584). By default, the configuration for all networks enables the `archive` feature for the RPC node. However, it is possible to disable this feature if needed.
@@ -130,6 +134,7 @@ index-node:
 ```
 
 #### Additional Resources
+
 More information on thegraph node documentation for [configuration toml - providers](https://github.com/graphprotocol/graph-node/blob/master/docs/config.md#configuring-ethereum-providers)
 
 ## Installing the Chart
@@ -152,12 +157,30 @@ same for previewnet:
 helm install sl charts/hedera-the-graph -f charts/hedera-the-graph/values-overrides/values-previewnet.yaml  
 ```
 
-
-
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
 
 ```bash
 helm uninstall my-release
+```
+
+## Port Forwarding
+
+If you want to deploy subgraphs on your local instance, you may want to forward the following ports
+
+```sh
+kubectl port-forward $QUERY_POD 8000 8020
+kubectl port-forward $IPFS_POD 5001
+```
+
+This will enable connections to
+
+- the GraphQL HTTP server at port `:8000`, used to query subgraphs, and
+- the JSON-RPC admin server at port `:8020`, used to create and deploy subgraphs.
+
+Moreover, if you want to access the Postgres database, you will need to forward the following port
+
+```sh
+kubectl port-forward $PG_POD 5432
 ```

--- a/charts/hedera-the-graph/values-overrides/arm-arch.yaml
+++ b/charts/hedera-the-graph/values-overrides/arm-arch.yaml
@@ -1,0 +1,9 @@
+
+# This file contains overrides for deploying Hedera The Graph on ARM64 architecture machines,
+# such as Apple Silicon Macs.
+ipfs:
+  # The charts provided by TrueCharts use amd64 by default.
+  # See https://truecharts.org/common/podoptions/#nodeselector for details.
+  podOptions:
+    nodeSelector:
+      kubernetes.io/arch: arm64

--- a/charts/hedera-the-graph/values-overrides/arm-arch.yaml
+++ b/charts/hedera-the-graph/values-overrides/arm-arch.yaml
@@ -4,6 +4,7 @@
 ipfs:
   # The charts provided by TrueCharts use amd64 by default.
   # See https://truecharts.org/common/podoptions/#nodeselector for details.
+  # To enable IPFS on ARM64, we need to change the `nodeSelector` to arm64.
   podOptions:
     nodeSelector:
       kubernetes.io/arch: arm64

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -59,6 +59,9 @@ ipfs:
   # Auto-generated from the ipfs sub-charts, Requiered if external ipfs is used
   host: ''
   port: 10125
+  # podOptions:
+  #   nodeSelector:
+  #     kubernetes.io/arch: arm64
 
 labels: {}
 
@@ -81,7 +84,7 @@ postgresql:
     size: 500Gi
   pgpool:
     childLifeTime: 60
-    childMaxConnections: 2
+    childMaxConnections: 50
     existingSecret: hedera-the-graph-passwords
     extraEnvVarsSecret: hedera-the-graph-passwords
     resources:

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -59,9 +59,9 @@ ipfs:
   # Auto-generated from the ipfs sub-charts, Requiered if external ipfs is used
   host: ''
   port: 10125
-  # podOptions:
-  #   nodeSelector:
-  #     kubernetes.io/arch: arm64
+  podOptions:
+    nodeSelector:
+      kubernetes.io/arch: arm64
 
 labels: {}
 

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -89,7 +89,7 @@ postgresql:
   pgpool:
     childLifeTime: 60
     # https://www.pgpool.net/docs/46/en/html/runtime-config-connection-pooling.html
-    childMaxConnections: 10
+    childMaxConnections: 20
     existingSecret: hedera-the-graph-passwords
     extraEnvVarsSecret: hedera-the-graph-passwords
     resources:

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -53,6 +53,8 @@ index-node:
         name: hedera-the-graph-passwords
   role: index-node
 
+# See the TrueCharts IPFS chart documentation for more details
+# https://truecharts.org/charts/stable/ipfs/
 ipfs:
   # Set to false if external ipfs is used
   enabled: true
@@ -67,9 +69,12 @@ labels: {}
 
 nameOverride: hedera-the-graph
 
+# See the Bitnami PostgreSQL HA chart documentation for more details
+# https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#readme
 postgresql:
   # Set to false if external postgresql is used
   enabled: true
+  # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#metrics-parameters
   metrics:
     enabled: false
     resources:
@@ -80,11 +85,14 @@ postgresql:
         cpu: 20m
         memory: 25Mi
   nameOverride: postgres
+  # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#persistence-parameters
   persistence:
     size: 500Gi
+  # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#pgpool-ii-parameters
   pgpool:
     childLifeTime: 60
-    childMaxConnections: 50
+    # https://www.pgpool.net/docs/46/en/html/runtime-config-connection-pooling.html
+    childMaxConnections: 10
     existingSecret: hedera-the-graph-passwords
     extraEnvVarsSecret: hedera-the-graph-passwords
     resources:
@@ -94,6 +102,7 @@ postgresql:
       requests:
         cpu: 200m
         memory: 256Mi
+  # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha#postgresql-with-repmgr-parameters
   postgresql:
     existingSecret: hedera-the-graph-passwords
     extraEnvVarsSecret: hedera-the-graph-passwords

--- a/charts/hedera-the-graph/values.yaml
+++ b/charts/hedera-the-graph/values.yaml
@@ -61,9 +61,6 @@ ipfs:
   # Auto-generated from the ipfs sub-charts, Requiered if external ipfs is used
   host: ''
   port: 10125
-  podOptions:
-    nodeSelector:
-      kubernetes.io/arch: arm64
 
 labels: {}
 


### PR DESCRIPTION
**Description**:

This PR includes support to run the umbrella chart in arm64 based architecture. See #222 why this is needed.

The charts provided by TrueCharts use `amd64` by default. See https://truecharts.org/common/podoptions/#nodeselector for details. This PR includes the following to enable IPFS running in `amd64` hosts.

```yaml
ipfs:
  podOptions:
    nodeSelector:
      kubernetes.io/arch: arm64
```

In addition, it also increases the number of connections allows by pgpool #220 and includes documentation about re-installing the chart #221.

In order to ensure CI runs properly, this PR also downgrades Helm version to `v3.17.3` as part of issue #224.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #222.
Fixes #220.
Fixes #224.
Fixes #221.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

> [!NOTE]
> ~~I assume that this won't work in AMD64 hosts. How can we enable a solution that works properly in both architectures?~~
> Solution provided by @AlfredoG87 https://github.com/hashgraph/hedera-the-graph/pull/223#discussion_r2112788257.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
