### PR TITLE
fix: allow `saucerswap/v2` subgraph to be deployed on testnet

### DIFF
--- a/subgraphs/saucerswap/v2/subgraph.template.yaml
+++ b/subgraphs/saucerswap/v2/subgraph.template.yaml
@@ -42,7 +42,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: Pool
-    network: mainnet
+    network: ${GRAPH_NETWORK}
     source:
       abi: Pool
     mapping:


### PR DESCRIPTION
**Description**:

This PR uses `GRAPH_NETWORK` variable to allow the `saucerswap/v2` subgraph to deployed on both testnet and mainnet.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #225.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

~~CI fails due to this https://github.com/hashgraph/hedera-the-graph/issues/224.~~ Fixed in https://github.com/hashgraph/hedera-the-graph/pull/223.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
