### PR TITLE
fix: pin `buildx` version to fix CI

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -55,8 +55,6 @@ jobs:
         with:
           context: ./auth-layer-proxy
           file: ./auth-layer-proxy/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-main

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          version: v0.22.0
           driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
 
       - name: Build and push images
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -14,7 +14,6 @@ permissions:
   packages: write
 
 env:
-  OWNER: hashgraph
   REGISTRY: ghcr.io
 
 jobs:
@@ -50,7 +49,7 @@ jobs:
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
 
-      - name: Build and push images
+      - name: Build and push auth-layer-proxy image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./auth-layer-proxy

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -13,8 +13,6 @@ permissions:
   packages: write
 
 env:
-  OWNER: hashgraph
-  PACKAGE_NAME: hedera-the-graph
   REGISTRY: ghcr.io
 
 jobs:
@@ -47,15 +45,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          version: v0.22.0
           driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
 
       - name: Build and push auth-layer-proxy image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./auth-layer-proxy
           file: ./auth-layer-proxy/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:auth-layer-proxy-${{ env.TAG }}

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ to [oss@hedera.com](mailto:oss@hedera.com).
 ## 🔐 Security
 
 Please do not file a public ticket mentioning the vulnerability.
-Refer to the security policy defined in the [SECURITY.md](https://github.com/hashgraph/hedera-sourcify/blob/main/SECURITY.md).
+Refer to the security policy defined in the [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
**Description**:

This PR fixes the `Release Integration Environment` and `Release Production Environment` workflows. It was a cache issue. See https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3657 and https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3625 for similar fixes in the Relay.

It also removes unused `OWNER` and `PACKAGE_NAME` `env` variables to avoid confusion.

Additionally, it fixes the security link in `README`.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #229.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
